### PR TITLE
Update voxels with lightmap

### DIFF
--- a/res/voxelize_frag.glsl
+++ b/res/voxelize_frag.glsl
@@ -52,7 +52,13 @@ void main() {
     if (useLightMap) {
         vec4 worldPos = texture(lightMap, fragTex);
         ivec3 voxelIndex = calculateVoxelIndex(worldPos.xyz);
-        imageStore(volume, voxelIndex, vec4(1, 1, 1, 1));
+        vec4 exist = imageLoad(volume, voxelIndex);
+        if (exist == vec4(0, 0, 0, 1) || exist == vec4(1, 1, 1, 1)) {
+            imageStore(volume, voxelIndex, vec4(1, 1, 1, 1));
+        }
+        else {
+            imageStore(volume, voxelIndex, vec4(1, 0, 0, 1));
+        }
     }
 
     if(voxelize) {

--- a/res/voxelize_frag.glsl
+++ b/res/voxelize_frag.glsl
@@ -21,6 +21,9 @@ uniform vec3 normal;
 uniform float normalStep;
 uniform float visibilityContrib;
 
+uniform sampler2D lightMap;
+uniform bool useLightMap;
+
 layout(binding=1, rgba16f) uniform image3D volume;
 
 out vec4 color;
@@ -46,11 +49,17 @@ void main() {
     float distR = 1 - (distance(center, fragPos)/radius);
     color = vec4(distR);
 
+    if (useLightMap) {
+        vec4 worldPos = texture(lightMap, fragTex);
+        ivec3 voxelIndex = calculateVoxelIndex(worldPos.xyz);
+        imageStore(volume, voxelIndex, vec4(1, 1, 1, 1));
+    }
+
     if(voxelize) {
         for(float j = 0; j < radius * distR; j += normalStep) {
             ivec3 voxelIndex = calculateVoxelIndex(fragPos + normal * j);
             /* Light voxelize - denote that this voxel has been voxelized by light */
-            imageStore(volume, voxelIndex, vec4(1, 0, 0, 1));
+            imageStore(volume, voxelIndex, vec4(0, 0, 0, 1));
 // #if GL_NV_shader_atomic_fp16_vector
 //             imageAtomicAdd(volume, voxelIndex, f16vec4(0, 0, 0, visibilityContrib));
 // #else

--- a/res/voxelize_frag.glsl
+++ b/res/voxelize_frag.glsl
@@ -59,9 +59,9 @@ void main() {
         else {
             imageStore(volume, voxelIndex, vec4(1, 0, 0, 1));
         }
+        color = worldPos;
     }
-
-    if(voxelize) {
+    else if(voxelize) {
         for(float j = 0; j < radius * distR; j += normalStep) {
             ivec3 voxelIndex = calculateVoxelIndex(fragPos + normal * j);
             /* Light voxelize - denote that this voxel has been voxelized by light */

--- a/res/voxelize_vert.glsl
+++ b/res/voxelize_vert.glsl
@@ -14,5 +14,5 @@ void main() {
     vec4 worldPos = M * Vi * vec4(vertPos, 1.0);
     gl_Position = P * V * worldPos;
     fragPos = worldPos.xyz;
-    fragTex = (vertPos.xy + 1.0) / 2.0;
+    fragTex = vertPos.xy + 0.5;
 }

--- a/src/Shaders/LightMapWriteShader.cpp
+++ b/src/Shaders/LightMapWriteShader.cpp
@@ -8,14 +8,15 @@
 
 #include "glm/gtc/matrix_transform.hpp"
 
-#define DEFAULT_SIZE 1024
-
 LightMapWriteShader::LightMapWriteShader(const std::string vert, const std::string frag) :
     Shader(vert, frag) {
     lightMap = new Texture();
 }
 
 bool LightMapWriteShader::init() {
+    lightMap->width = Window::width;
+    lightMap->height = Window::height;
+
     if (!Shader::init()) {
         return false;
     }
@@ -26,7 +27,6 @@ bool LightMapWriteShader::init() {
     addUniform("V");
     addUniform("M");
 
-    lightMap->width = lightMap->height = DEFAULT_SIZE;
     initFBO();
 
     return true;
@@ -34,7 +34,6 @@ bool LightMapWriteShader::init() {
 
 void LightMapWriteShader::render(std::vector<VolumeShader::Voxel> & voxels) {
     /* Reset light map */
-    CHECK_GL_CALL(glViewport(0, 0, lightMap->width, lightMap->height));
     CHECK_GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fboHandle));
     CHECK_GL_CALL(glClearColor(0.f, 0.f, 0.f, 0.f));
     CHECK_GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
@@ -76,7 +75,6 @@ void LightMapWriteShader::render(std::vector<VolumeShader::Voxel> & voxels) {
     CHECK_GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, 0));
     CHECK_GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     unbind();
-    CHECK_GL_CALL(glViewport(0, 0, Window::width, Window::height));
     CHECK_GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 }
 
@@ -89,8 +87,8 @@ void LightMapWriteShader::initFBO() {
     CHECK_GL_CALL(glBindTexture(GL_TEXTURE_2D, lightMap->textureId));
     CHECK_GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB32F, lightMap->width, lightMap->height, 0, GL_RGB, GL_FLOAT, NULL));
 
-    CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-    CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+    CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+    CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
     CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     CHECK_GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 

--- a/src/Shaders/LightMapWriteShader.cpp
+++ b/src/Shaders/LightMapWriteShader.cpp
@@ -36,6 +36,7 @@ void LightMapWriteShader::render(std::vector<VolumeShader::Voxel> & voxels) {
     /* Reset light map */
     CHECK_GL_CALL(glViewport(0, 0, lightMap->width, lightMap->height));
     CHECK_GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fboHandle));
+    CHECK_GL_CALL(glClearColor(0.f, 0.f, 0.f, 0.f));
     CHECK_GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
     bind();
@@ -61,12 +62,14 @@ void LightMapWriteShader::render(std::vector<VolumeShader::Voxel> & voxels) {
 
     glm::mat4 M;
     for (auto v : voxels) {
-        M  = glm::mat4(1.f);
-        M *= glm::translate(glm::mat4(1.f), v.spatial.position);
-        M *= glm::scale(glm::mat4(1.f), v.spatial.scale);
-        loadMat4(getUniform("M"), &M);
+        if (v.data.r || v.data.g || v.data.b || v.data.a) {
+            M  = glm::mat4(1.f);
+            M *= glm::translate(glm::mat4(1.f), v.spatial.position);
+            M *= glm::scale(glm::mat4(1.f), v.spatial.scale);
+            loadMat4(getUniform("M"), &M);
 
-        CHECK_GL_CALL(glDrawElements(GL_TRIANGLES, (int)Library::cube->eleBuf.size(), GL_UNSIGNED_INT, nullptr));
+            CHECK_GL_CALL(glDrawElements(GL_TRIANGLES, (int)Library::cube->eleBuf.size(), GL_UNSIGNED_INT, nullptr));
+        }
     }
 
     CHECK_GL_CALL(glBindVertexArray(0));

--- a/src/Shaders/VolumeShader.hpp
+++ b/src/Shaders/VolumeShader.hpp
@@ -24,11 +24,11 @@ class VolumeShader : public Shader {
 
         /* Generate 3D volume */
         void clearVolume();
-        void voxelize(glm::mat4, glm::mat4, glm::vec3);
-        void renderMesh(glm::mat4, glm::mat4, glm::vec3, bool);
+        void voxelize(glm::mat4, glm::mat4, glm::vec3, GLuint);
+        void renderMesh(glm::mat4, glm::mat4, glm::vec3, bool, GLuint);
 
-        /* Getters */
-        std::vector<Voxel> & getVoxelData() { return voxelData; }
+        std::vector<Voxel> & getVoxelData() { updateVoxelData(); return voxelData; }
+        void updateVoxelData();
 
         glm::vec2 xBounds;
         glm::vec2 yBounds;
@@ -47,10 +47,8 @@ class VolumeShader : public Shader {
         /* Volume vars */
         GLuint volumeHandle;
         Spatial *volQuad;
-
-        /* Data stored in voxels */
-        // TODO : a fixed-size array and write over values 
         std::vector<Voxel> voxelData;
+
 };
 
 #endif

--- a/src/Shaders/VolumeShader.hpp
+++ b/src/Shaders/VolumeShader.hpp
@@ -27,7 +27,7 @@ class VolumeShader : public Shader {
         void voxelize(glm::mat4, glm::mat4, glm::vec3, GLuint);
         void renderMesh(glm::mat4, glm::mat4, glm::vec3, bool, GLuint);
 
-        std::vector<Voxel> & getVoxelData() { updateVoxelData(); return voxelData; }
+        std::vector<Voxel> & getVoxelData() { return voxelData; }
         void updateVoxelData();
 
         glm::vec2 xBounds;
@@ -38,7 +38,7 @@ class VolumeShader : public Shader {
 
         float normalStep = 0.2f;
         float visibilityContrib = 0.02f;
- 
+
      private:
         void initVolume();
         glm::ivec3 get3DIndices(int);
@@ -46,7 +46,7 @@ class VolumeShader : public Shader {
 
         /* Volume vars */
         GLuint volumeHandle;
-        Spatial *volQuad;
+        Spatial * volQuad;
         std::vector<Voxel> voxelData;
 
 };

--- a/src/Shaders/VoxelShader.cpp
+++ b/src/Shaders/VoxelShader.cpp
@@ -52,23 +52,25 @@ void VoxelShader::render(std::vector<VolumeShader::Voxel> & voxels) {
 
     glm::mat4 M;
     for (auto v : voxels) {
-        M  = glm::mat4(1.f);
-        M *= glm::translate(glm::mat4(1.f), v.spatial.position);
-        M *= glm::scale(glm::mat4(1.f), v.spatial.scale);
-        loadMat4(getUniform("M"), &M);
+        if (v.data.r || v.data.g || v.data.b || v.data.a) {
+            M = glm::mat4(1.f);
+            M *= glm::translate(glm::mat4(1.f), v.spatial.position);
+            M *= glm::scale(glm::mat4(1.f), v.spatial.scale);
+            loadMat4(getUniform("M"), &M);
 
-        loadVec4(getUniform("voxelData"), v.data);
+            loadVec4(getUniform("voxelData"), v.data);
 
-        /* Draw shape */
-        loadBool(getUniform("isOutline"), false);
-        CHECK_GL_CALL(glDrawElements(GL_TRIANGLES, (int)Library::cube->eleBuf.size(), GL_UNSIGNED_INT, nullptr));
-
-        /* Draw outline */
-        if (drawOutline) {
-            loadBool(getUniform("isOutline"), true);
-            CHECK_GL_CALL(glPolygonMode(GL_FRONT_AND_BACK, GL_LINE));
+            /* Draw shape */
+            loadBool(getUniform("isOutline"), false);
             CHECK_GL_CALL(glDrawElements(GL_TRIANGLES, (int)Library::cube->eleBuf.size(), GL_UNSIGNED_INT, nullptr));
-            CHECK_GL_CALL(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL));
+
+            /* Draw outline */
+            if (drawOutline) {
+                loadBool(getUniform("isOutline"), true);
+                CHECK_GL_CALL(glPolygonMode(GL_FRONT_AND_BACK, GL_LINE));
+                CHECK_GL_CALL(glDrawElements(GL_TRIANGLES, (int)Library::cube->eleBuf.size(), GL_UNSIGNED_INT, nullptr));
+                CHECK_GL_CALL(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL));
+            }
         }
    }
 

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -4,17 +4,17 @@ Size=417,63
 Collapsed=0
 
 [Light]
-Pos=950,39
+Pos=954,39
 Size=310,356
 Collapsed=0
 
 [Billboards]
-Pos=14,483
+Pos=943,414
 Size=400,324
-Collapsed=1
+Collapsed=0
 
 [Volume]
-Pos=19,389
+Pos=30,494
 Size=385,451
 Collapsed=0
 

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -4,12 +4,12 @@ Size=417,63
 Collapsed=0
 
 [Light]
-Pos=954,39
+Pos=870,459
 Size=310,356
 Collapsed=0
 
 [Billboards]
-Pos=943,414
+Pos=468,19
 Size=400,324
 Collapsed=0
 

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -4,24 +4,24 @@ Size=417,63
 Collapsed=0
 
 [Light]
-Pos=870,459
-Size=310,356
+Pos=925,571
+Size=334,363
 Collapsed=0
 
 [Billboards]
 Pos=468,19
 Size=400,324
-Collapsed=0
+Collapsed=1
 
 [Volume]
-Pos=30,494
-Size=385,451
-Collapsed=0
+Pos=27,580
+Size=396,361
+Collapsed=1
 
 [Stats]
 Pos=8,18
 Size=434,124
-Collapsed=0
+Collapsed=1
 
 [Font]
 Pos=79,603


### PR DESCRIPTION
Voxelize shader now has two paths:
A preliminary path where an empty volume's voxels are initialized with basic black data in the shape of a sphere point at the light source. 
A secondary path path where existing active (black) voxels are updated based on a position map. Voxels are updated to white if there is mapping from position map to active voxel. Voxels are updated to red if there is no mapping from position map to active voxel (invalid). 

Allowing two paths like this means less rewriting of volume/voxel code across the board. It is still messy though.